### PR TITLE
Fix AAD node silently falling back to gpt-4o instead of configured LLM

### DIFF
--- a/anomaly_detection/anomaly_detection/anomaly_detection_node.py
+++ b/anomaly_detection/anomaly_detection/anomaly_detection_node.py
@@ -29,6 +29,7 @@ from collections import deque
 
 import rclpy
 import yaml
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
 from anomaly_msg.msg import AnomalyMsg
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
@@ -630,17 +631,21 @@ class AnomalyDetectionNode(Node):
 
         Resolution order:
           1) AAD_CONFIG_PATH environment variable
-          2) config.yaml in the same folder as this script
+          2) config.yaml installed in this package's share directory
+          3) config.yaml in the same folder as this script
 
         Returns
         -------
             dict: Configuration dictionary. Empty if loading fails.
         """
-        env_path = os.getenv("AAD_CONFIG_PATH")
-        if env_path and os.path.isfile(env_path):
-            config_path = env_path
-        else:
-            config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+        config_path = os.getenv("AAD_CONFIG_PATH")
+        if not config_path or not os.path.isfile(config_path):
+            try:
+                config_path = os.path.join(
+                    get_package_share_directory("anomaly_detection"), "config.yaml"
+                )
+            except PackageNotFoundError:
+                config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
 
         if not os.path.isfile(config_path):
             self.get_logger().warn(

--- a/anomaly_detection/anomaly_detection/llm_client.py
+++ b/anomaly_detection/anomaly_detection/llm_client.py
@@ -11,6 +11,7 @@ import yaml
 from io import BytesIO
 from PIL import Image
 import base64
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
 from dotenv import load_dotenv
 from ollama import Client
 
@@ -70,11 +71,21 @@ class LLMClient:
         self.api_base = None
         self.system_prompt = None
 
-        # Match the same config resolution style as anomaly_detection_node.py
+        # Match the same config resolution order as anomaly_detection_node.py:
+        # explicit arg/AAD_CONFIG_PATH > installed package share dir > script-relative fallback
         if config_path is None:
-            config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
-        elif not os.path.isabs(config_path):
+            config_path = os.getenv("AAD_CONFIG_PATH")
+
+        if config_path and not os.path.isabs(config_path):
             config_path = os.path.abspath(config_path)
+
+        if not config_path or not os.path.isfile(config_path):
+            try:
+                config_path = os.path.join(
+                    get_package_share_directory("anomaly_detection"), "config.yaml"
+                )
+            except PackageNotFoundError:
+                config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
 
         if os.path.isfile(config_path):
             try:

--- a/anomaly_detection/package.xml
+++ b/anomaly_detection/package.xml
@@ -13,6 +13,7 @@
   <test_depend>python3-pytest</test_depend>
 
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>anomaly_msg</exec_depend>
   <build_depend>anomaly_msg</build_depend>
   <build_export_depend>anomaly_msg</build_export_depend>

--- a/anomaly_detection/setup.py
+++ b/anomaly_detection/setup.py
@@ -20,6 +20,8 @@ setup(
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name, 'launch'),
             glob('launch/*.launch.py')),
+        (os.path.join('share', package_name),
+            ['anomaly_detection/config.yaml']),
 
     ],
     entry_points={


### PR DESCRIPTION
config.yaml was never installed by colcon (missing from setup.py's data_files), so anomaly_detection_node.py and llm_client.py each resolved config.yaml relative to their own installed __file__ location and found nothing, silently falling back to hardcoded defaults (openai/gpt-4o) instead of the local Ollama model configured in config.yaml.

- Package config.yaml into the installed share directory.
- Resolve config path via AAD_CONFIG_PATH env var, then the installed package share directory, then a script-relative fallback.
- Apply the same resolution in llm_client.py, which previously had its own independent (and even narrower) lookup that ignored AAD_CONFIG_PATH entirely.




